### PR TITLE
Ci/release cycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
           skip_existing: true
       - name: Publish distribution to PyPI
-        # Configure commitizen to push tag events https://github.com/commitizen-tools/commitizen/issues/271
-        # if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.pypi_password }}

--- a/Makefile
+++ b/Makefile
@@ -144,3 +144,13 @@ security:
 	bandit -r src
 
 	@echo ""
+
+.PHONY: release
+release:
+	@echo "----------------------"
+	@echo "- Generating Release -"
+	@echo "----------------------"
+
+	cz bump --changelog
+
+	@echo ""


### PR DESCRIPTION
## Change Summary

ci: restrict the publishing to PyPI to commits with tag refs
chore: create make release command 