### PR TITLE
fix: correct the formatting of single line module docstrings.

### DIFF
--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -32,6 +32,7 @@ def test_corrects_one_file(runner, tmpdir) -> None:
     test_file = tmpdir.join("source.py")
     test_file.write("os.getcwd()")
     fixed_source = """import os
+
 os.getcwd()"""
 
     result = runner.invoke(cli, [str(test_file)])
@@ -49,6 +50,7 @@ def test_corrects_three_file(runner, tmpdir) -> None:
         test_file.write("os.getcwd()")
         test_files.append(test_file)
     fixed_source = """import os
+
 os.getcwd()"""
 
     result = runner.invoke(cli, [str(test_file) for test_file in test_files])
@@ -62,6 +64,7 @@ def test_corrects_code_from_stdin(runner) -> None:
     """Correct the source code passed as stdin."""
     source = "os.getcwd()"
     fixed_source = """import os
+
 os.getcwd()"""
 
     result = runner.invoke(cli, ["-"], input=source)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,6 +1,5 @@
 """Tests the service layer."""
 
-
 from autoimport.services import fix_code
 
 
@@ -8,6 +7,7 @@ def test_fix_code_adds_missing_import() -> None:
     """Understands that os is a package and add it to the top of the file."""
     source = "os.getcwd()"
     fixed_source = """import os
+
 os.getcwd()"""
 
     result = fix_code(source)
@@ -34,7 +34,26 @@ os.getcwd()'''
     fixed_source = '''"""Module docstring
 
 """
+
 import os
+
+os.getcwd()'''
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
+def test_fix_imports_packages_below_single_line_docstring() -> None:
+    """Imports are located below the module docstrings when they only take one line."""
+    source = '''"""Module docstring."""
+
+import pytest
+os.getcwd()'''
+    fixed_source = '''"""Module docstring."""
+
+import os
+
 os.getcwd()'''
 
     result = fix_code(source)
@@ -47,6 +66,7 @@ def test_fix_imports_type_hints() -> None:
     source = """def function(dictionary: Dict) -> None:
     pass"""
     fixed_source = """from typing import Dict
+
 def function(dictionary: Dict) -> None:
     pass"""
 
@@ -60,6 +80,7 @@ def test_fix_substitutes_aliases() -> None:
     source = """getcwd()"""
     aliases = {"getcwd": "from os import getcwd"}
     fixed_source = """from os import getcwd
+
 getcwd()"""
 
     result = fix_code(source, aliases)


### PR DESCRIPTION
fix: add newline between module docstring, import statements and code.

## Change Summary

fix: correct the formatting of single line module docstrings.
fix: add newline between module docstring, import statements and code.

## Checklist

* [x] Unit tests for the changes exist.
* [x] Tests pass on CI and coverage remains at 100%.
* [x] Documentation reflects the changes where applicable.
