### PR TITLE
Feat/move imports to top

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ example by configuring your editor to run it when saving the file.
 pip install autoimport
 ```
 
-# A Simple Example
+# Usage
 
 Imagine we've got the following source code:
 
@@ -72,7 +72,29 @@ os.getcwd()
 
 !!! warning ""
     `autoimport` will add all dependencies at the top of the file, we suggest
-    using [isort](https://pycqa.github.io/isort) afterwards to clean the file.
+    using [isort](https://pycqa.github.io/isort) and
+    [black](https://black.readthedocs.io/en/stable/) afterwards to clean the
+    file.
+
+## Moving the imports to the top
+
+There are going to be import cases that may not work, if you find one, please
+[open an
+issue](https://github.com/lyz-code/autoimport/issues/new?labels=bug&template=bug.md).
+
+While we fix it you can write the import statement wherever you are in the file
+and the next time you run `autoimport` it will get moved to the top.
+
+If you don't want a specific line to go to the top, add the `# noqa: autoimport`
+at the end. For example:
+
+```python
+a = 1
+
+from os import getcwd # noqa: autoimport
+
+getcwd()
+```
 
 # References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,12 @@ pylint = [
 ]
 mccabe = ["+*"]
 pep8-naming = ["+*"]
-pycodestyle = ["+*"]
+pycodestyle = [
+  "+*",
+  "-W503", # No longer applies, incompatible with newer version of PEP8
+           # see https://github.com/PyCQA/pycodestyle/issues/197
+           # and https://github.com/psf/black/issues/113
+  ]
 pyflakes = ["+*"]
 
 [tool.flakehell.exceptions."tests/"]

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 """Python package building configuration."""
 
+import re
 from glob import glob
 from os.path import basename, splitext
-from typing import Dict
 
 from setuptools import find_packages, setup
 
-# Avoid loading the package before requirements are installed:
-version: Dict[str, str] = {}
-
+# Avoid loading the package to extract the version
 with open("src/autoimport/version.py") as fp:
-    exec(fp.read(), version)
+    version_match = re.search(r'__version__ = "(?P<version>.*)"', fp.read())
+    if version_match is None:
+        raise ValueError("The version is not specified in the version.py file.")
+    version = version_match["version"]
 
 setup(
     name="autoimport",
-    version=version["__version__"],
+    version=version,
     description="A Cookiecutter template for creating Python projects",
     author="Lyz",
     author_email="lyz-code-security-advisories@riseup.net",

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,6 +1,7 @@
 """Test the command line interface."""
 
 import re
+from textwrap import dedent
 
 import pytest
 from click.testing import CliRunner
@@ -31,9 +32,12 @@ def test_corrects_one_file(runner, tmpdir) -> None:
     """Correct the source code of a file."""
     test_file = tmpdir.join("source.py")
     test_file.write("os.getcwd()")
-    fixed_source = """import os
+    fixed_source = dedent(
+        """\
+        import os
 
-os.getcwd()"""
+        os.getcwd()"""
+    )
 
     result = runner.invoke(cli, [str(test_file)])
 
@@ -49,9 +53,12 @@ def test_corrects_three_file(runner, tmpdir) -> None:
         test_file = tmpdir.join(f"source_{file_number}.py")
         test_file.write("os.getcwd()")
         test_files.append(test_file)
-    fixed_source = """import os
+    fixed_source = dedent(
+        """\
+        import os
 
-os.getcwd()"""
+        os.getcwd()"""
+    )
 
     result = runner.invoke(cli, [str(test_file) for test_file in test_files])
 
@@ -63,9 +70,12 @@ os.getcwd()"""
 def test_corrects_code_from_stdin(runner) -> None:
     """Correct the source code passed as stdin."""
     source = "os.getcwd()"
-    fixed_source = """import os
+    fixed_source = dedent(
+        """\
+        import os
 
-os.getcwd()"""
+        os.getcwd()"""
+    )
 
     result = runner.invoke(cli, ["-"], input=source)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -159,11 +159,13 @@ def test_fix_removes_unneeded_imports_in_beginning_of_from_statements() -> None:
     source = dedent(
         """\
         from os import path, getcwd
+
         getcwd()"""
     )
     fixed_source = dedent(
         """\
         from os import getcwd
+
         getcwd()"""
     )
 
@@ -179,12 +181,14 @@ def test_fix_removes_unneeded_imports_in_middle_of_from_statements() -> None:
     source = dedent(
         """\
         from os import getcwd, path, mkdir
+
         getcwd()
         mkdir()"""
     )
     fixed_source = dedent(
         """\
         from os import getcwd, mkdir
+
         getcwd()
         mkdir()"""
     )
@@ -201,14 +205,127 @@ def test_fix_removes_unneeded_imports_in_end_of_from_statements() -> None:
     source = dedent(
         """\
         from os import getcwd, path
+
         getcwd()"""
     )
     fixed_source = dedent(
         """\
         from os import getcwd
+
         getcwd()"""
     )
 
     result = fix_code(source)
 
     assert result == fixed_source
+
+
+def test_fix_moves_import_statements_to_the_top() -> None:
+    """Move import statements present in the source code to the top of the file"""
+    source = dedent(
+        """\
+        a = 3
+
+        import os
+        os.getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        import os
+
+        a = 3
+
+        os.getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
+def test_fix_moves_import_statements_in_indented_code_to_the_top() -> None:
+    """Move import statements present indented in the source code
+    to the top of the file
+    """
+    source = dedent(
+        """\
+        a = 3
+
+
+        def test():
+            import os
+            os.getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        import os
+
+        a = 3
+
+
+        def test():
+            os.getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
+def test_fix_moves_from_import_statements_to_the_top() -> None:
+    """Move from import statements present in the source code to the top of the file"""
+    source = dedent(
+        """\
+        a = 3
+
+        from os import getcwd
+        getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import getcwd
+
+        a = 3
+
+        getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
+def test_fix_doesnt_break_objects_with_import_in_their_names() -> None:
+    """Objects that have the import name in their name should not be changed."""
+    source = dedent(
+        """\
+        def import_code():
+            pass
+
+        def code_import():
+            pass
+
+        def import():
+            pass
+
+        import_string = 'a'"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source
+
+
+def test_fix_doesnt_move_import_statements_with_noqa_to_the_top() -> None:
+    """Ignore lines that have # noqa: autoimport."""
+    source = dedent(
+        """\
+        a = 3
+
+        from os import getcwd # noqa: autoimport
+        getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,14 +1,19 @@
 """Tests the service layer."""
 
+from textwrap import dedent
+
 from autoimport.services import fix_code
 
 
 def test_fix_code_adds_missing_import() -> None:
     """Understands that os is a package and add it to the top of the file."""
     source = "os.getcwd()"
-    fixed_source = """import os
+    fixed_source = dedent(
+        """\
+        import os
 
-os.getcwd()"""
+        os.getcwd()"""
+    )
 
     result = fix_code(source)
 
@@ -26,18 +31,24 @@ def test_fix_doesnt_change_source_if_package_doesnt_exist() -> None:
 
 def test_fix_imports_packages_below_docstring() -> None:
     """Imports are located below the module docstrings."""
-    source = '''"""Module docstring
+    source = dedent(
+        '''\
+        """Module docstring
 
-"""
-import pytest
-os.getcwd()'''
-    fixed_source = '''"""Module docstring
+        """
+        import pytest
+        os.getcwd()'''
+    )
+    fixed_source = dedent(
+        '''\
+        """Module docstring
 
-"""
+        """
 
-import os
+        import os
 
-os.getcwd()'''
+        os.getcwd()'''
+    )
 
     result = fix_code(source)
 
@@ -46,15 +57,21 @@ os.getcwd()'''
 
 def test_fix_imports_packages_below_single_line_docstring() -> None:
     """Imports are located below the module docstrings when they only take one line."""
-    source = '''"""Module docstring."""
+    source = dedent(
+        '''\
+        """Module docstring."""
 
-import pytest
-os.getcwd()'''
-    fixed_source = '''"""Module docstring."""
+        import pytest
+        os.getcwd()'''
+    )
+    fixed_source = dedent(
+        '''\
+        """Module docstring."""
 
-import os
+        import os
 
-os.getcwd()'''
+        os.getcwd()'''
+    )
 
     result = fix_code(source)
 
@@ -63,12 +80,18 @@ os.getcwd()'''
 
 def test_fix_imports_type_hints() -> None:
     """Typing objects are initialized with their required header."""
-    source = """def function(dictionary: Dict) -> None:
-    pass"""
-    fixed_source = """from typing import Dict
+    source = dedent(
+        """\
+        def function(dictionary: Dict) -> None:
+            pass"""
+    )
+    fixed_source = dedent(
+        """\
+        from typing import Dict
 
-def function(dictionary: Dict) -> None:
-    pass"""
+        def function(dictionary: Dict) -> None:
+            pass"""
+    )
 
     result = fix_code(source)
 
@@ -79,9 +102,12 @@ def test_fix_substitutes_aliases() -> None:
     """Missing import statements are loaded from the alias if there is a match."""
     source = """getcwd()"""
     aliases = {"getcwd": "from os import getcwd"}
-    fixed_source = """from os import getcwd
+    fixed_source = dedent(
+        """\
+        from os import getcwd
 
-getcwd()"""
+        getcwd()"""
+    )
 
     result = fix_code(source, aliases)
 
@@ -100,8 +126,11 @@ def test_fix_doesnt_fail_if_object_not_in_aliases() -> None:
 
 def test_fix_removes_unneeded_imports() -> None:
     """If there is an import statement of an unused package it should be removed."""
-    source = """import requests
-foo = 1"""
+    source = dedent(
+        """\
+        import requests
+        foo = 1"""
+    )
     fixed_source = "foo = 1"
 
     result = fix_code(source)
@@ -111,8 +140,11 @@ foo = 1"""
 
 def test_fix_removes_unneeded_imports_in_from_statements() -> None:
     """Remove `from package import` statement of an unused packages."""
-    source = """from os import path
-foo = 1"""
+    source = dedent(
+        """\
+        from os import path
+        foo = 1"""
+    )
     fixed_source = "foo = 1"
 
     result = fix_code(source)
@@ -124,10 +156,16 @@ def test_fix_removes_unneeded_imports_in_beginning_of_from_statements() -> None:
     """Remove unused `object_name` in `from package import object_name, other_object`
     statements.
     """
-    source = """from os import path, getcwd
-getcwd()"""
-    fixed_source = """from os import getcwd
-getcwd()"""
+    source = dedent(
+        """\
+        from os import path, getcwd
+        getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import getcwd
+        getcwd()"""
+    )
 
     result = fix_code(source)
 
@@ -138,12 +176,18 @@ def test_fix_removes_unneeded_imports_in_middle_of_from_statements() -> None:
     """Remove unused `object_name` in
     `from package import other_object, object_name, other_used_object` statements.
     """
-    source = """from os import getcwd, path, mkdir
-getcwd()
-mkdir()"""
-    fixed_source = """from os import getcwd, mkdir
-getcwd()
-mkdir()"""
+    source = dedent(
+        """\
+        from os import getcwd, path, mkdir
+        getcwd()
+        mkdir()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import getcwd, mkdir
+        getcwd()
+        mkdir()"""
+    )
 
     result = fix_code(source)
 
@@ -154,10 +198,16 @@ def test_fix_removes_unneeded_imports_in_end_of_from_statements() -> None:
     """Remove unused `object_name` in `from package import other_object, object_name`
     statements.
     """
-    source = """from os import getcwd, path
-getcwd()"""
-    fixed_source = """from os import getcwd
-getcwd()"""
+    source = dedent(
+        """\
+        from os import getcwd, path
+        getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import getcwd
+        getcwd()"""
+    )
 
     result = fix_code(source)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- See https://lyz-code.github.io/autoimport/contributing for help on Contributing -->

## Change Summary

* feat: move import statements to the top

Import statements should not be in the middle of the code, but on top,
so if autoimport finds anyone, it will move it.

This is useful to write the import statement wherever you are, so you
don't have to go up to the beginning of the file each time autoimport is
not able to detect a missing import.

* style(services): organize the functions.

So they can be read upside down.

* fix(setup.py): extract the version from source without exec statement

exec is known to generate vulnerabilities, use a regular expression
instead.

style(tests): use dedent to make the tests source code cleaner.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist.
* [x] Tests pass on CI and coverage remains at 100%.
* [x] Documentation reflects the changes where applicable.
