### PR TITLE
fix: remove unused imported objects in multiline from import statements

### DIFF
--- a/src/autoimport/services.py
+++ b/src/autoimport/services.py
@@ -308,6 +308,19 @@ def _remove_unused_imports(source_code: str, import_name: str, line_number: int)
             imports.remove(object_name)
             new_imports = ", ".join(imports)
             source_code_lines[line_number] = f"{match['from']} {new_imports}"
+    # If it's a multiline import statement
+    # fmt: off
+    # Format is required until there is no more need of the
+    # experimental-string-processing flag of the Black formatter.
+    elif re.match(
+        fr"from {package_name} import .*?\($",
+        source_code_lines[line_number],
+    ):
+        # fmt: on
+        while line_number + 1 < len(source_code_lines):
+            line_number += 1
+            if re.match(fr"\s*?{object_name},?", source_code_lines[line_number]):
+                source_code_lines.pop(line_number)
 
     fixed_source_code: str = "\n".join(source_code_lines)
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -152,6 +152,35 @@ def test_fix_removes_unneeded_imports_in_from_statements() -> None:
     assert result == fixed_source
 
 
+def test_fix_removes_unused_imports_in_multiline_from_statements() -> None:
+    """
+    Given: A source code with multiline import from statements.
+    When: fix_code is run
+    Then: Unused import statements are deleted
+    """
+    source = dedent(
+        """\
+        from os import (
+            getcwd,
+            path,
+        )
+
+        getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import (
+            getcwd,
+        )
+
+        getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
 def test_fix_removes_unneeded_imports_in_beginning_of_from_statements() -> None:
     """Remove unused `object_name` in `from package import object_name, other_object`
     statements.


### PR DESCRIPTION
<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
