### PR TITLE
feat: Add imports of the local package objects

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,8 @@ objects:
 
 * The modules referenced in `PYTHONPATH`.
 * The `typing` library objects.
+* The objects of the Python project you are developing, assuming you are
+    executing the program in a directory of the project and you can import it.
 * The common statements.
 
 Where some of the common statements are:

--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,6 @@ ignore_missing_imports = True
 
 [mypy-_io.*]
 ignore_missing_imports = True
+
+[mypy-pyprojroot.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setup(
         [console_scripts]
         autoimport=autoimport.entrypoints.cli:cli
     """,
-    install_requires=["autoflake", "Click"],
+    install_requires=["autoflake", "Click", "pyprojroot"],
 )

--- a/tests/unit/test_extract_package.py
+++ b/tests/unit/test_extract_package.py
@@ -1,0 +1,52 @@
+"""Test the extraction of package objects."""
+
+from autoimport.model import extract_package_objects
+
+
+def test_extraction_returns_the_package_functions() -> None:
+    """
+    Given: A package with functions.
+    When: extract package objects is called
+    Then: All the functions are extracted
+    """
+    result = extract_package_objects("autoimport")
+
+    desired_objects = {
+        "fix_code": "from autoimport import fix_code",
+        "fix_files": "from autoimport import fix_files",
+        "extract_package_objects": (
+            "from autoimport.model import extract_package_objects"
+        ),
+    }
+    for object_name, object_import_string in desired_objects.items():
+        assert result[object_name] == object_import_string
+
+
+def test_extraction_returns_the_package_classes() -> None:
+    """
+    Given: A package with classes.
+    When: extract package objects is called.
+    Then: All the classes are extracted.
+    """
+    result = extract_package_objects("autoimport")
+
+    desired_objects = {
+        "SourceCode": "from autoimport.model import SourceCode",
+    }
+    for object_name, object_import_string in desired_objects.items():
+        assert result[object_name] == object_import_string
+
+
+def test_extraction_returns_the_package_dictionaries() -> None:
+    """
+    Given: A package with dictionaries.
+    When: extract package objects is called.
+    Then: All the dictionaries are extracted.
+    """
+    result = extract_package_objects("autoimport")
+
+    desired_objects = {
+        "common_statements": "from autoimport.model import common_statements",
+    }
+    for object_name, object_import_string in desired_objects.items():
+        assert result[object_name] == object_import_string

--- a/tests/unit/test_extract_package.py
+++ b/tests/unit/test_extract_package.py
@@ -50,3 +50,14 @@ def test_extraction_returns_the_package_dictionaries() -> None:
     }
     for object_name, object_import_string in desired_objects.items():
         assert result[object_name] == object_import_string
+
+
+def test_extraction_returns_empty_dict_if_package_is_not_importable() -> None:
+    """
+    Given: Autoimport can't import the package.
+    When: the extract package objects is called.
+    Then: An empty directory is returned
+    """
+    result = extract_package_objects("inexistent")
+
+    assert result == {}

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -623,3 +623,28 @@ def test_fix_autoimports_common_imports(import_key: str, import_statement: str) 
     result = fix_code(source)
 
     assert result == fixed_source
+
+
+def test_fix_autoimports_objects_defined_in_the_root_of_the_package() -> None:
+    """
+    Given:
+        The fix code is run from a directory that belongs to a python project package.
+        And a source code with an object that needs an import statement.
+        And that object belongs to the root of the python package.
+    When: Fix code is run.
+    Then: The import is done
+    """
+    source = dedent(
+        """\
+        fix_code()"""
+    )
+    fixed_source = dedent(
+        """\
+        from autoimport import fix_code
+
+        fix_code()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source


### PR DESCRIPTION
Now autoimport will import the objects of the Python project you are
developing, assuming you are executing the program in a directory of the
project and you can import it.

<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->
closes #37 

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
