### PR TITLE
fix: import developing package objects when not in src directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,18 @@ docs: test-examples
 	@echo ""
 
 .PHONY: bump
-bump: bump-version build-package upload-pypi clean
+bump: pull-master bump-version build-package upload-pypi clean
+
+.PHONY: pull-master
+pull-master:
+	@echo "------------------------"
+	@echo "- Updating repository  -"
+	@echo "------------------------"
+
+	git checkout master
+	git pull
+
+	@echo ""
 
 .PHONY: build-package
 build-package:

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,25 +85,34 @@ objects:
 
 * The modules referenced in `PYTHONPATH`.
 * The `typing` library objects.
-* The objects of the Python project you are developing, assuming you are
-    executing the program in a directory of the project and you can import it.
 * The common statements.
 
-Where some of the common statements are:
+    Where some of the common statements are:
 
-* `BeautifulSoup` -> `from bs4 import BeautifulSoup`
-* `call` -> `from unittest.mock import call`
-* `CaptureFixture` -> `from _pytest.capture import CaptureFixture`
-* `CliRunner` -> `from click.testing import CliRunner`
-* `copyfile` -> `from shutil import copyfile`
-* `dedent` -> `from textwrap import dedent`
-* `LocalPath` -> `from py._path.local import LocalPath`
-* `LogCaptureFixture` -> `from _pytest.logging import LogCaptureFixture`
-* `Mock` -> `from unittest.mock import Mock`
-* `patch` -> `from unittest.mock import patch`
-* `StringIO` -> `from io import StringIO`
-* `TempdirFactory` -> `from _pytest.tmpdir import TempdirFactory`
-* `YAMLError` -> `from yaml import YAMLError`
+        * `BeautifulSoup` -> `from bs4 import BeautifulSoup`
+        * `call` -> `from unittest.mock import call`
+        * `CaptureFixture` -> `from _pytest.capture import CaptureFixture`
+        * `CliRunner` -> `from click.testing import CliRunner`
+        * `copyfile` -> `from shutil import copyfile`
+        * `dedent` -> `from textwrap import dedent`
+        * `LocalPath` -> `from py._path.local import LocalPath`
+        * `LogCaptureFixture` -> `from _pytest.logging import LogCaptureFixture`
+        * `Mock` -> `from unittest.mock import Mock`
+        * `patch` -> `from unittest.mock import patch`
+        * `StringIO` -> `from io import StringIO`
+        * `TempdirFactory` -> `from _pytest.tmpdir import TempdirFactory`
+        * `YAMLError` -> `from yaml import YAMLError`
+
+* The objects of the Python project you are developing, assuming you are
+    executing the program in a directory of the project and you can import it.
+
+!!! warning "It may not work if you use pip install -e ."
+    Given that you execute `autoimport` inside a virtualenv where the package is
+    installed with `pip install -e .`, when there is an import error in a file
+    that is indexed in the package, `autoimport` won't be able to read the
+    package contents as the `import` statement will fail. So it's a good idea to
+    run autoimport from a virtualenv that has a stable version of the package we
+    are developing.
 
 ## Remove unused import statements
 

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -222,7 +222,9 @@ class SourceCode:  # noqa: R090
         project_package = os.path.basename(here()).replace("-", "_")
         package_objects = extract_package_objects(project_package)
 
-        if package_objects is None:
+        # nocover: as the tests are run inside the autoimport virtualenv, it will
+        # always find the objects on that package
+        if package_objects is None:  # pragma: nocover
             return None
         try:
             return package_objects[name]

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -208,7 +208,8 @@ class SourceCode:  # noqa: R090
                 return package
         return None
 
-    def _find_package_in_our_project(self, name: str) -> Optional[str]:
+    @staticmethod
+    def _find_package_in_our_project(name: str) -> Optional[str]:
         """Search the name in the objects of the package we are developing.
 
         Args:

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 
 import pytest
 from click.testing import CliRunner
+from py._path.local import LocalPath
 
 from autoimport.entrypoints.cli import cli
 from autoimport.version import __version__
@@ -28,9 +29,9 @@ def test_version(runner: CliRunner) -> None:
     )
 
 
-def test_corrects_one_file(runner: CliRunner, tmpdir) -> None:
+def test_corrects_one_file(runner: CliRunner, tmpdir: LocalPath) -> None:
     """Correct the source code of a file."""
-    test_file = tmpdir.join("source.py")
+    test_file = tmpdir.join("source.py")  # type: ignore
     test_file.write("os.getcwd()")
     fixed_source = dedent(
         """\
@@ -46,11 +47,11 @@ def test_corrects_one_file(runner: CliRunner, tmpdir) -> None:
 
 
 @pytest.mark.secondary
-def test_corrects_three_files(runner: CliRunner, tmpdir) -> None:
+def test_corrects_three_files(runner: CliRunner, tmpdir: LocalPath) -> None:
     """Correct the source code of multiple files."""
     test_files = []
     for file_number in range(3):
-        test_file = tmpdir.join(f"source_{file_number}.py")
+        test_file = tmpdir.join(f"source_{file_number}.py")  # type: ignore
         test_file.write("os.getcwd()")
         test_files.append(test_file)
     fixed_source = dedent(

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -648,3 +648,25 @@ def test_fix_autoimports_objects_defined_in_the_root_of_the_package() -> None:
     result = fix_code(source)
 
     assert result == fixed_source
+
+
+def test_fix_autoimports_objects_defined_in___all__special_variable() -> None:
+    """
+    Given: Some missing packages in the __all__ variable
+    When: Fix code is run.
+    Then: The import is done
+    """
+    source = dedent(
+        """\
+        __all__ = ['fix_code']"""
+    )
+    fixed_source = dedent(
+        """\
+        from autoimport import fix_code
+
+        __all__ = ['fix_code']"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source


### PR DESCRIPTION
When executed in the tests directory, autoimport was not able to import
the package objects because there was an error finding the project root
directory.

feat: import objects defined in the __all__ special variable

docs: warn that the object finding in developing package may fail.

Given that you execute `autoimport` inside a virtualenv where the
package is installed with `pip install -e .`, when there is an import
error in a file that is indexed in the package, `autoimport` won't be
able to read the package contents as the `import` statement will fail.
So it's a good idea to run autoimport from a virtualenv that has
a stable version of the package we are developing.

refactor: remove the unused path attribute of SourceCode

<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
