### PR TITLE
Fix/try import statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.4.2 (2020-12-29)
+
+### Fix
+
+- wrong import indentation when moving up the imports.
+
+### perf
+
+- common import statements are now run sooner
+
 ## 0.4.1 (2020-12-29)
 
 ### Fix

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ bump-version:
 
 	cz bump --changelog --no-verify
 	git push --tags
+	git push
 
 	@echo ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.4.1"
+version = "0.4.2"
 tag_format = "$version"
 version_files = [
     "src/autoimport/version.py",

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -42,7 +42,6 @@ bandit
 mypy
 
 # Formatters
-autoimport
 black
 isort
 yamlfix

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -103,11 +103,14 @@ class SourceCode:  # noqa: R090
         """
         import_start_line = len(self.docstring)
         multiline_import = False
+        try_line: Optional[str] = None
 
         for line in source_lines[import_start_line:]:
             if re.match(r"^if TYPE_CHECKING:$", line):
                 break
-            if (
+            if re.match(r"^(try|except.*):$", line):
+                try_line = line
+            elif (
                 re.match(r"^\s*(from .*)?import.[^\'\"]*$", line)
                 or line == ""
                 or multiline_import
@@ -117,6 +120,11 @@ class SourceCode:  # noqa: R090
                     multiline_import = True
                 elif ")" in line:
                     multiline_import = False
+
+                if try_line:
+                    self.imports.append(try_line)
+                    try_line = None
+
                 self.imports.append(line)
             else:
                 break

--- a/src/autoimport/version.py
+++ b/src/autoimport/version.py
@@ -3,7 +3,7 @@
 import platform
 import sys
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 
 
 def version_info() -> str:

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -698,3 +698,27 @@ def test_fix_respects_type_checking_import_statements() -> None:
     result = fix_code(source)
 
     assert result == source
+
+
+def test_fix_respects_try_except_in_import_statements() -> None:
+    """
+    Given: Code with try except statements in the imports.
+    When: Fix code is run
+    Then: The try except statements are respected
+    """
+    source = dedent(
+        """\
+        import os
+
+        try:
+            from typing import TypedDict  # noqa
+        except ImportError:
+            from mypy_extensions import TypedDict  # <=3.7
+
+        os.getcwd()
+        Movie = TypedDict('Movie', {'name': str, 'year': int})"""
+    )
+
+    result = fix_code(source)
+
+    assert result == source


### PR DESCRIPTION
<!--
Thank you for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is, try to link it with open issues -->
Code as the following should not change after autoimport is run:

```python
import os

try:
    from typing import TypedDict  # noqa
except ImportError:
    from mypy_extensions import TypedDict  # <=3.7

os.getcwd()

Movie = TypedDict('Movie', {'name': str, 'year': int})
```

## Checklist

* [x] Add test cases to all the changes you introduce
* [x] Update the documentation for the changes
