### PR TITLE
Expose pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: autoimport
+  name: autoimport
+  entry: autoimport
+  require_serial: true
+  language: python
+  language_version: python3
+  types_or: [cython, pyi, python]
+  args: []
+  minimum_pre_commit_version: '2.9.0'

--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -1,14 +1,23 @@
 For a smother experience, you can run `autoimport` each time you save your file
-in your editor.
+in your editor or make a commit.
+
+# [pre-commit](https://pre-commit.com/)
+
+You can run `autoimport` before we do a commit using the
+[pre-commit](https://pre-commit.com/) framework. If you don't know how to use
+it, follow [these
+guidelines](https://lyz-code.github.io/blue-book/devops/ci/#configuring-pre-commit).
+
+You'll need to add the following lines to your project's
+`.pre-commit-config.yaml` file.
+
+```yaml
+repos:
+  - repo: https://github.com/lyz-code/autoimport/
+    rev: master
+    hooks:
+      - id: autoimport
+```
 
 # Vim
-
-To integrate `autoimport` into Vim, I recommend using the [ale
-plugin](https://github.com/dense-analysis/ale).
-
-!!! note ""
-
-    If you are new to ALE, check [this
-    post](https://lyz-code.github.io/blue-book/linux/vim/vim_plugins/#ale).
-
-`ale` is configured to run `autoimport` automatically by default.
+...

--- a/docs/editor_integration.md
+++ b/docs/editor_integration.md
@@ -1,5 +1,18 @@
-For a smother experience, you can run `autoimport` each time you save your file
-in your editor or make a commit.
+For a smoother experience, you can run `autoimport` automatically each
+time each time you save your file in your editor and each time you
+perform a `git commit`.
+
+# Vim
+
+To integrate `autoimport` into Vim, I recommend using the [ale
+plugin](https://github.com/dense-analysis/ale).
+
+!!! note ""
+
+    If you are new to ALE, check [this
+    post](https://lyz-code.github.io/blue-book/linux/vim/vim_plugins/#ale).
+
+`ale` is configured to run `autoimport` automatically by default.
 
 # [pre-commit](https://pre-commit.com/)
 
@@ -18,6 +31,3 @@ repos:
     hooks:
       - id: autoimport
 ```
-
-# Vim
-...


### PR DESCRIPTION
## Description

I added the file `.pre-commit-hooks.yml` so I could add this project to my pre-commit config like so:

```
repos:
  - repo: https://github.com/rtts/autoimport/
    rev: master
    hooks:
      - id: autoimport
```
