### PR TITLE
Fix AttributeError for Python >=3.8

### DIFF
--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -301,7 +301,7 @@ class SourceCode:  # noqa: R090
         Returns:
             import_string: String required to import the package.
         """
-        package_specs = importlib.util.find_spec(name)  # type: ignore
+        package_specs = importlib.util.find_spec(name)
 
         try:
             importlib.util.module_from_spec(package_specs)  # type: ignore

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -1,6 +1,6 @@
 """Define the entities."""
 
-import importlib
+import importlib.util
 import inspect
 import os
 import re


### PR DESCRIPTION
Importing `importlib` and then making calls like `importlib.util.*` causes `AttributeError: module 'importlib' has no attribute 'util'` in Python 3.8 and higher. I've encountered this for 3.8 myself and there is a [bug report](https://bugs.python.org/issue41958) for 3.9. The solution is to import `importlib.shutil` explicitly. This change doesn't break anything in older versions of Python.