### PR TITLE
feat: `~/.config/autoimport/config.toml` support, `affect_indented_imports` configuration

### DIFF
--- a/src/autoimport/entrypoints/cli.py
+++ b/src/autoimport/entrypoints/cli.py
@@ -4,7 +4,6 @@ import logging
 from typing import Optional, Tuple
 
 import click
-from maison.config import ProjectConfig
 
 from autoimport import services, version
 
@@ -13,14 +12,28 @@ log = logging.getLogger(__name__)
 
 @click.command()
 @click.version_option(version="", message=version.version_info())
-@click.option("--config-file", default=None)
+@click.option(
+    "--config-file",
+    default=None,
+    help="File to read config from, instead of `./pyproject.toml`",
+)
+@click.option(
+    "--no-global-config",
+    is_flag=True,
+    default=False,
+    help=f"Disable reading `{services.GLOBAL_CONFIG_PATH}`",
+)
 @click.argument("files", type=click.File("r+"), nargs=-1)
-def cli(files: Tuple[str], config_file: Optional[str] = None) -> None:
+def cli(
+    files: Tuple[str],
+    config_file: Optional[str] = None,
+    no_global_config: bool = False,
+) -> None:
     """Corrects the source code of the specified files."""
-    config = ProjectConfig(
-        project_name="autoimport",
-        source_files=[config_file] if config_file else None,
-    ).to_dict()
+    config = services.read_configs(
+        config_file=config_file,
+        no_global_config=no_global_config,
+    )
     try:
         fixed_code = services.fix_files(files, config)
     except FileNotFoundError as error:

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -52,6 +52,8 @@ class SourceCode:  # noqa: R090
         self.code: List[str] = []
         self.config: Dict[str, Any] = config if config else {}
         self._trailing_newline = False
+        self._affect_indented_imports = self.config.get("affect_indented_imports", True)
+        self._import_line_re_prefix = r"^\s*" if self._affect_indented_imports else r"^"
         self._split_code(source_code)
 
     def fix(self) -> str:
@@ -133,7 +135,10 @@ class SourceCode:  # noqa: R090
             if re.match(r"^(try|except.*):$", line):
                 try_line = line
             elif (
-                re.match(r"^\s*(from .*)?import.[^\'\"]*$", line)
+                re.match(
+                    self._import_line_re_prefix + r"(from .*)?import.[^\'\"]*$",
+                    line,
+                )
                 or line == ""
                 or multiline_import
             ):
@@ -225,7 +230,10 @@ class SourceCode:  # noqa: R090
             if (
                 "=" not in line
                 and not multiline_string
-                and re.match(r"^\s*(?:from .*)?import .[^\'\"]*$", line)
+                and re.match(
+                    self._import_line_re_prefix + r"(?:from .*)?import .[^\'\"]*$",
+                    line,
+                )
             ) or multiline_import:
                 # Ignore the lines containing # noqa: autoimport
                 if re.match(r".*?# ?noqa:.*?autoimport.*", line):

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -10,6 +10,9 @@ from py._path.local import LocalPath
 from autoimport.entrypoints.cli import cli
 from autoimport.version import __version__
 
+# When invoking the CLI for tests, ignore the config outside the repository.
+COMMON_OPTIONS = ["--no-global-config"]
+
 
 @pytest.fixture(name="runner")
 def fixture_runner() -> CliRunner:
@@ -19,7 +22,7 @@ def fixture_runner() -> CliRunner:
 
 def test_version(runner: CliRunner) -> None:
     """Prints program version when called with --version."""
-    result = runner.invoke(cli, ["--version"])
+    result = runner.invoke(cli, COMMON_OPTIONS + ["--version"])
 
     assert result.exit_code == 0
     assert re.match(
@@ -40,7 +43,7 @@ def test_corrects_one_file(runner: CliRunner, tmpdir: LocalPath) -> None:
         os.getcwd()"""
     )
 
-    result = runner.invoke(cli, [str(test_file)])
+    result = runner.invoke(cli, COMMON_OPTIONS + [str(test_file)])
 
     assert result.exit_code == 0
     assert test_file.read() == fixed_source
@@ -61,7 +64,10 @@ def test_corrects_three_files(runner: CliRunner, tmpdir: LocalPath) -> None:
         os.getcwd()"""
     )
 
-    result = runner.invoke(cli, [str(test_file) for test_file in test_files])
+    result = runner.invoke(
+        cli,
+        COMMON_OPTIONS + [str(test_file) for test_file in test_files],
+    )
 
     assert result.exit_code == 0
     for test_file in test_files:
@@ -78,7 +84,7 @@ def test_corrects_code_from_stdin(runner: CliRunner) -> None:
         os.getcwd()"""
     )
 
-    result = runner.invoke(cli, ["-"], input=source)
+    result = runner.invoke(cli, COMMON_OPTIONS + ["-"], input=source)
 
     assert result.exit_code == 0
     assert result.stdout == fixed_source
@@ -104,7 +110,7 @@ def test_pyproject_common_statements(runner: CliRunner, tmpdir: LocalPath) -> No
     test_file.write(PYPROJECT_CONFIG_TEST_SOURCE)
     with tmpdir.as_cwd():
 
-        result = runner.invoke(cli, [str(test_file)])
+        result = runner.invoke(cli, COMMON_OPTIONS + [str(test_file)])
 
     assert result.exit_code == 0
     assert test_file.read() == PYPROJECT_CONFIG_FIXED_SOURCE
@@ -121,7 +127,10 @@ def test_config_path_argument(runner: CliRunner, tmpdir: LocalPath) -> None:
     test_file = code_dir / "source.py"
     test_file.write(PYPROJECT_CONFIG_TEST_SOURCE)
 
-    result = runner.invoke(cli, ["--config-file", str(pyproject_toml), str(test_file)])
+    result = runner.invoke(
+        cli,
+        COMMON_OPTIONS + ["--config-file", str(pyproject_toml), str(test_file)],
+    )
 
     assert result.exit_code == 0
     assert test_file.read() == PYPROJECT_CONFIG_FIXED_SOURCE

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -647,6 +647,8 @@ def test_fix_autoimports_objects_defined_in_the_root_of_the_package() -> None:
         And that object belongs to the root of the python package.
     When: Fix code is run.
     Then: The import is done
+
+    Note that for this test the current folder must be named `autoimport`.
     """
     source = dedent(
         """\
@@ -669,6 +671,8 @@ def test_fix_autoimports_objects_defined_in___all__special_variable() -> None:
     Given: Some missing packages in the __all__ variable
     When: Fix code is run.
     Then: The import is done
+
+    Note that for this test the current folder must be named `autoimport`.
     """
     source = dedent(
         """\


### PR DESCRIPTION
Prior discussion: https://github.com/lyz-code/autoimport/issues/169#issuecomment-989100892

I opted to merge two configs instead of looking for them in order.

As always, if there are no objections to the general changes, I'll add tests and docs.

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
