### PR TITLE
Ignore fmt skip comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -135,7 +135,7 @@ While we fix it you can write the import statement wherever you are in the file
 and the next time you run `autoimport` it will get moved to the top.
 
 If you don't want a specific line to go to the top, add the `# noqa: autoimport`
-at the end. For example:
+or `# fmt: skip` at the end. For example:
 
 ```python
 a = 1

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -204,6 +204,16 @@ class SourceCode:  # noqa: R090
 
         return source_code
 
+    @staticmethod
+    def _should_ignore_line(line: str) -> bool:
+        """Determine whether a line should be ignored by autoimport or not."""
+        return any(
+            [
+                re.match(r".*?# ?fmt:.*?skip.*", line),
+                re.match(r".*?# ?noqa:.*?autoimport.*", line),
+            ]
+        )
+
     def _move_imports_to_top(self) -> None:
         """Fix python source code to move import statements to the top of the file.
 
@@ -228,8 +238,7 @@ class SourceCode:  # noqa: R090
                 and not multiline_string
                 and re.match(r"^\s*(?:from .*)?import .[^\'\"]*$", line)
             ) or multiline_import:
-                # Ignore the lines containing # noqa: autoimport
-                if re.match(r".*?# ?noqa:.*?autoimport.*", line):
+                if self._should_ignore_line(line):
                     continue
 
                 # process lines using separation markers
@@ -418,8 +427,7 @@ class SourceCode:  # noqa: R090
         object_name = import_name.split(".")[-1]
 
         for line in self.imports:
-            # Ignore the lines containing # noqa: autoimport
-            if re.match(r".*?# ?noqa:.*?autoimport.*", line):
+            if self._should_ignore_line(line):
                 continue
 
             # If it's the only line, remove it

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -503,6 +503,21 @@ def test_fix_doesnt_fail_on_noqa_lines_on_unused_import() -> None:
     assert result == source
 
 
+def test_fix_respects_fmt_skip_lines() -> None:
+    """Ignore lines that have # fmt: skip."""
+    source = dedent(
+        """
+        def why():
+            import pdb;pdb.set_trace()  # fmt: skip
+            return 'dunno'
+        """
+    ).replace("\n", "", 1)
+
+    result = fix_code(source)
+
+    assert result == source
+
+
 def test_fix_respects_noqa_in_from_import_lines_in_multiple_lines() -> None:
     """
     Given: Multiple from X import Y lines, some with multiline format with noqa


### PR DESCRIPTION
<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->
Checks whether lines have `# fmt: skip` and skips them.

Fixes https://github.com/lyz-code/autoimport/issues/182

## Checklist

* [x ] Add test cases to all the changes you introduce
* [ x] Update the documentation for the changes
