### PR TITLE
support backslashed multiline imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.6.0
     hooks:
       - id: black
         language_version: python3.7
@@ -20,6 +20,8 @@ repos:
         id: mypy
         args: [--no-warn-unused-ignores, --ignore-missing-imports]
         files: src
+        additional_dependencies:
+          - 'pydantic'
   # - repo: https://github.com/flakehell/flakehell/
   #   rev: v.0.8.0
   #   hooks:

--- a/src/autoimport/model.py
+++ b/src/autoimport/model.py
@@ -139,9 +139,9 @@ class SourceCode:  # noqa: R090
                 or multiline_import
             ):
                 # Process multiline import statements
-                if "(" in line:
+                if "(" in line or line[-1:] == "\\":
                     multiline_import = True
-                elif ")" in line:
+                elif ")" in line and line[-1:] != "\\":
                     multiline_import = False
 
                 if try_line:
@@ -249,9 +249,9 @@ class SourceCode:  # noqa: R090
                     continue
 
                 # Process multiline import statements
-                if "(" in line:
+                if "(" in line or line[-1:] == "\\":
                     multiline_import = True
-                elif ")" in line:
+                elif ")" in line and line[-1:] != "\\":
                     multiline_import = False
 
                 code_lines_to_remove.append(line)
@@ -450,7 +450,8 @@ class SourceCode:  # noqa: R090
                 # fmt: on
                 if match is not None:
                     line_number = self.imports.index(line)
-                    imports = match["imports"].split(", ")
+                    imports_no_dups = " ".join(match["imports"].split())
+                    imports = imports_no_dups.split(", ")
                     imports.remove(object_name)
                     new_imports = ", ".join(imports)
                     self.imports[line_number] = f"{match['from']} {new_imports}"
@@ -460,7 +461,7 @@ class SourceCode:  # noqa: R090
             # Format is required until there is no more need of the
             # experimental-string-processing flag of the Black formatter.
             elif re.match(
-                fr"from {package_name} import .*?\($",
+                fr"from {package_name} import .*?[\(\\]$",
                 line,
             ):
                 # fmt: on

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -179,6 +179,31 @@ def test_fix_removes_unused_imports_in_multiline_from_statements() -> None:
     assert result == fixed_source
 
 
+def test_fix_removes_unused_imports_in_backslashed_multiline_from_statements() -> None:
+    """
+    Given: A source code with backslashed multiline import from statements.
+    When: fix_code is run
+    Then: Unused import statements are deleted
+    """
+    source = dedent(
+        """\
+        from os import getcwd, \
+            path
+
+        getcwd()"""
+    )
+    fixed_source = dedent(
+        """\
+        from os import getcwd
+
+        getcwd()"""
+    )
+
+    result = fix_code(source)
+
+    assert result == fixed_source
+
+
 def test_fix_removes_unneeded_imports_in_beginning_of_from_statements() -> None:
     """Remove unused `object_name` in `from package import object_name, other_object`
     statements.


### PR DESCRIPTION
I'm not sure my changes are suitable for the master, but i need autoimport for non black-formatted pep8 code with backslashed multiline imports.

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
