### PR TITLE
If input is received from stdin, output the unmodified value to stdout.

### DIFF
--- a/src/autoimport/services.py
+++ b/src/autoimport/services.py
@@ -28,7 +28,7 @@ def fix_files(
         source = file_wrapper.read()
         fixed_source = fix_code(source, config)
 
-        if fixed_source == source:
+        if fixed_source == source and file_wrapper.name != '<stdin>':
             continue
 
         try:

--- a/src/autoimport/services.py
+++ b/src/autoimport/services.py
@@ -28,7 +28,7 @@ def fix_files(
         source = file_wrapper.read()
         fixed_source = fix_code(source, config)
 
-        if fixed_source == source and file_wrapper.name != '<stdin>':
+        if fixed_source == source and file_wrapper.name != "<stdin>":
             continue
 
         try:


### PR DESCRIPTION
<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce

Not sure if it is possible to provide a test for this sort of behavior:

```
            # Click testing runner doesn't simulate correctly the reading from stdin
            # instead of setting the name attribute to `<stdin>` it gives an
            # AttributeError. But when you use it outside testing, no AttributeError
            # is raised and name has the value <stdin>. So there is no way of testing
            # this behaviour.
```

* [x] Update the documentation for the changes

Correct behavior is already documented in https://github.com/lyz-code/autoimport/blob/a8eb5510f3bd82cfa7a1ee63d98839ce49a0b152/src/autoimport/services.py#L19
