### PR TITLE
Restrict maison version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "autoflake>=1.4",
     "pyprojroot>=0.2.0",
     "sh>=1.14.2",
-    "maison>=1.4.0",
+    "maison>=1.4.0,<2.0.0",
     "xdg>=6.0.0",
 ]
 name = "autoimport"


### PR DESCRIPTION
Limit `maison>=1.4.0,<2.0.0`. #258

I saw that in the commit history, version bump was done separately by the author after merging the PR, so I did not bump the version myself.  Let me know if you want me to do that.